### PR TITLE
feat: add all option to pagination

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -6,6 +6,7 @@ interface PaginationProps {
   totalPages: number;
   totalItems: number;
   pageSize: number;
+  isAll?: boolean;
   query: {
     ipOrDomain?: string;
     region?: string;
@@ -18,7 +19,8 @@ const Pagination: React.FC<PaginationProps> = ({
   totalPages,
   totalItems,
   pageSize,
-  query
+  query,
+  isAll = false
 }) => {
   // Determine which page links to show
   const getPageNumbers = () => {
@@ -60,7 +62,17 @@ const Pagination: React.FC<PaginationProps> = ({
     if (query.region) params.append('region', query.region);
     if (query.service) params.append('service', query.service);
     if (page > 1) params.append('page', page.toString());
-    
+
+    return `/?${params.toString()}`;
+  };
+
+  const getAllUrl = () => {
+    const params = new URLSearchParams();
+    if (query.ipOrDomain) params.append('ipOrDomain', query.ipOrDomain);
+    if (query.region) params.append('region', query.region);
+    if (query.service) params.append('service', query.service);
+    params.append('pageSize', 'all');
+
     return `/?${params.toString()}`;
   };
   
@@ -68,8 +80,8 @@ const Pagination: React.FC<PaginationProps> = ({
   if (totalPages <= 1) return null;
   
   // Calculate range of items being shown
-  const startItem = (currentPage - 1) * pageSize + 1;
-  const endItem = Math.min(currentPage * pageSize, totalItems);
+  const startItem = isAll ? 1 : (currentPage - 1) * pageSize + 1;
+  const endItem = isAll ? totalItems : Math.min(currentPage * pageSize, totalItems);
   
   // Get pages to display
   const pageNumbers = getPageNumbers();
@@ -82,7 +94,7 @@ const Pagination: React.FC<PaginationProps> = ({
 
       <div className="flex gap-2" role="navigation" aria-label="Pagination">
         {/* Previous button */}
-        {currentPage > 1 && (
+        {!isAll && currentPage > 1 && (
           <Link href={getPageUrl(currentPage - 1)} className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200">
             Previous
           </Link>
@@ -100,7 +112,7 @@ const Pagination: React.FC<PaginationProps> = ({
               key={page}
               href={getPageUrl(page)}
               className={`px-3 py-1 rounded-md text-sm ${
-                currentPage === page
+                !isAll && currentPage === page
                   ? 'bg-blue-600 text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
               }`}
@@ -109,9 +121,19 @@ const Pagination: React.FC<PaginationProps> = ({
             </Link>
           );
         })}
+
+        {/* All option */}
+        <Link
+          href={getAllUrl()}
+          className={`px-3 py-1 rounded-md text-sm ${
+            isAll ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+          }`}
+        >
+          All
+        </Link>
         
         {/* Next button */}
-        {currentPage < totalPages && (
+        {!isAll && currentPage < totalPages && (
           <Link href={getPageUrl(currentPage + 1)} className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200">
             Next
           </Link>

--- a/src/components/SimplePagination.tsx
+++ b/src/components/SimplePagination.tsx
@@ -3,9 +3,10 @@ import React from 'react';
 interface SimplePaginationProps {
   currentPage: number;
   totalPages: number;
-  onPageChange: (page: number) => void;
+  onPageChange: (page: number | 'all') => void;
   totalItems: number;
   pageSize: number;
+  isAll?: boolean;
 }
 
 const SimplePagination: React.FC<SimplePaginationProps> = ({
@@ -13,14 +14,15 @@ const SimplePagination: React.FC<SimplePaginationProps> = ({
   totalPages,
   onPageChange,
   totalItems,
-  pageSize
+  pageSize,
+  isAll = false
 }) => {
   // Don't render pagination if we only have one page
   if (totalPages <= 1) return null;
 
   // Calculate range of items being shown
-  const startItem = (currentPage - 1) * pageSize + 1;
-  const endItem = Math.min(currentPage * pageSize, totalItems);
+  const startItem = isAll ? 1 : (currentPage - 1) * pageSize + 1;
+  const endItem = isAll ? totalItems : Math.min(currentPage * pageSize, totalItems);
 
   // Determine which page links to show
   const getPageNumbers = () => {
@@ -65,9 +67,9 @@ const SimplePagination: React.FC<SimplePaginationProps> = ({
 
       <div className="flex gap-2" role="navigation" aria-label="Pagination">
         {/* Previous button */}
-        {currentPage > 1 && (
-          <button 
-            onClick={() => onPageChange(currentPage - 1)} 
+        {!isAll && currentPage > 1 && (
+          <button
+            onClick={() => onPageChange(currentPage - 1)}
             className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200"
           >
             Previous
@@ -86,7 +88,7 @@ const SimplePagination: React.FC<SimplePaginationProps> = ({
               key={page}
               onClick={() => onPageChange(page)}
               className={`px-3 py-1 rounded-md text-sm ${
-                currentPage === page
+                !isAll && currentPage === page
                   ? 'bg-blue-600 text-white'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
               }`}
@@ -95,11 +97,21 @@ const SimplePagination: React.FC<SimplePaginationProps> = ({
             </button>
           );
         })}
+
+        {/* All option */}
+        <button
+          onClick={() => onPageChange('all')}
+          className={`px-3 py-1 rounded-md text-sm ${
+            isAll ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+          }`}
+        >
+          All
+        </button>
         
         {/* Next button */}
-        {currentPage < totalPages && (
-          <button 
-            onClick={() => onPageChange(currentPage + 1)} 
+        {!isAll && currentPage < totalPages && (
+          <button
+            onClick={() => onPageChange(currentPage + 1)}
             className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200"
           >
             Next

--- a/src/pages/api/ipAddress.ts
+++ b/src/pages/api/ipAddress.ts
@@ -24,10 +24,12 @@ export default async function handler(
   }
 
   const { ipOrDomain, region, service, page = '1', pageSize = '50' } = req.query
-  
-  // Parse pagination parameters
+
+  // Parse pagination parameters, supporting "all" to return all results
   const currentPage = parseInt(Array.isArray(page) ? page[0] : page, 10) || 1
-  const itemsPerPage = parseInt(Array.isArray(pageSize) ? pageSize[0] : pageSize, 10) || 50
+  const rawPageSize = Array.isArray(pageSize) ? pageSize[0] : pageSize
+  const showAll = rawPageSize === 'all'
+  const itemsPerPage = showAll ? Infinity : parseInt(rawPageSize, 10) || 50
   
   // Convert array parameters to string if needed
   const ipOrDomainStr = Array.isArray(ipOrDomain) ? ipOrDomain[0] : ipOrDomain
@@ -58,14 +60,16 @@ export default async function handler(
         if (results && results.length > 0) {
           const total = results.length;
           const startIndex = (currentPage - 1) * itemsPerPage;
-          const paginatedResults = results.slice(startIndex, startIndex + itemsPerPage);
-          
+          const paginatedResults = showAll
+            ? results
+            : results.slice(startIndex, startIndex + itemsPerPage);
+
           return res.status(200).json({
             results: paginatedResults,
             query: { service: serviceParam, region: regionParam },
             total,
-            page: currentPage,
-            pageSize: itemsPerPage
+            page: showAll ? 1 : currentPage,
+            pageSize: showAll ? total : itemsPerPage
           });
         }
       } catch (error) {
@@ -89,14 +93,16 @@ export default async function handler(
           if (serviceResult && serviceResult.length > 0) {
             const total = serviceResult.length;
             const startIndex = (currentPage - 1) * itemsPerPage;
-            const paginatedResults = serviceResult.slice(startIndex, startIndex + itemsPerPage);
-            
+            const paginatedResults = showAll
+              ? serviceResult
+              : serviceResult.slice(startIndex, startIndex + itemsPerPage);
+
             return res.status(200).json({
               results: paginatedResults,
               query: { service: ipOrDomainStr },
               total,
-              page: currentPage,
-              pageSize: itemsPerPage
+              page: showAll ? 1 : currentPage,
+              pageSize: showAll ? total : itemsPerPage
             });
           }
           
@@ -106,14 +112,16 @@ export default async function handler(
           if (regionResult && regionResult.length > 0) {
             const total = regionResult.length;
             const startIndex = (currentPage - 1) * itemsPerPage;
-            const paginatedResults = regionResult.slice(startIndex, startIndex + itemsPerPage);
-            
+            const paginatedResults = showAll
+              ? regionResult
+              : regionResult.slice(startIndex, startIndex + itemsPerPage);
+
             return res.status(200).json({
               results: paginatedResults,
               query: { region: ipOrDomainStr },
               total,
-              page: currentPage,
-              pageSize: itemsPerPage
+              page: showAll ? 1 : currentPage,
+              pageSize: showAll ? total : itemsPerPage
             });
           }
         } catch (error) {
@@ -148,14 +156,16 @@ export default async function handler(
       // Apply pagination
       const total = filteredResults.length
       const startIndex = (currentPage - 1) * itemsPerPage
-      const paginatedResults = filteredResults.slice(startIndex, startIndex + itemsPerPage)
-      
+      const paginatedResults = showAll
+        ? filteredResults
+        : filteredResults.slice(startIndex, startIndex + itemsPerPage)
+
       return res.status(200).json({
         results: paginatedResults,
         query: { ipOrDomain: ipOrDomainStr, region: regionStr, service: serviceStr },
         total,
-        page: currentPage,
-        pageSize: itemsPerPage
+        page: showAll ? 1 : currentPage,
+        pageSize: showAll ? total : itemsPerPage
       })
     } 
     // If we have region or service, use the search functionality directly
@@ -172,14 +182,16 @@ export default async function handler(
       // Apply pagination
       const total = results.length
       const startIndex = (currentPage - 1) * itemsPerPage
-      const paginatedResults = results.slice(startIndex, startIndex + itemsPerPage)
-      
+      const paginatedResults = showAll
+        ? results
+        : results.slice(startIndex, startIndex + itemsPerPage)
+
       return res.status(200).json({
         results: paginatedResults,
         query: { region: regionStr, service: serviceStr },
         total,
-        page: currentPage,
-        pageSize: itemsPerPage
+        page: showAll ? 1 : currentPage,
+        pageSize: showAll ? total : itemsPerPage
       })
     } 
     // No valid search parameters

--- a/src/pages/service-tags/[serviceTag].tsx
+++ b/src/pages/service-tags/[serviceTag].tsx
@@ -33,6 +33,7 @@ export default function ServiceTagDetail() {
   const router = useRouter();
   const { serviceTag } = router.query;
   const [currentPage, setCurrentPage] = useState(1);
+  const [isAll, setIsAll] = useState(false);
   
   const { data, error, isLoading } = useSWR<ServiceTagDetailResponse>(
     serviceTag ? `/api/service-tags?serviceTag=${encodeURIComponent(serviceTag as string)}` : null,
@@ -42,11 +43,12 @@ export default function ServiceTagDetail() {
   // Paginate results
   const paginatedResults = useMemo(() => {
     if (!data?.ipRanges) return [];
-    
+    if (isAll) return data.ipRanges;
+
     const startIndex = (currentPage - 1) * PAGE_SIZE;
     const endIndex = startIndex + PAGE_SIZE;
     return data.ipRanges.slice(startIndex, endIndex);
-  }, [data?.ipRanges, currentPage]);
+  }, [data?.ipRanges, currentPage, isAll]);
 
   const totalPages = Math.ceil((data?.ipRanges?.length || 0) / PAGE_SIZE);
 
@@ -169,9 +171,18 @@ export default function ServiceTagDetail() {
               <SimplePagination
                 currentPage={currentPage}
                 totalPages={totalPages}
-                onPageChange={setCurrentPage}
+                onPageChange={(page) => {
+                  if (page === 'all') {
+                    setIsAll(true);
+                    setCurrentPage(1);
+                  } else {
+                    setIsAll(false);
+                    setCurrentPage(page);
+                  }
+                }}
                 totalItems={data.ipRanges.length}
                 pageSize={PAGE_SIZE}
+                isAll={isAll}
               />
             )}
           </>


### PR DESCRIPTION
## Summary
- add `All` toggle to pagination components
- handle `pageSize=all` in API and pages to fetch every item
- export now includes all displayed results when `All` is active

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689519e9e0d4833198df07e1ee0f399f