### PR TITLE
Improve pagination controls and results header

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 interface PaginationProps {
   currentPage: number;
@@ -20,6 +21,7 @@ const Pagination: React.FC<PaginationProps> = ({
   pageSize,
   query
 }) => {
+  const router = useRouter();
   // Determine which page links to show
   const getPageNumbers = () => {
     const pages = [];
@@ -60,61 +62,93 @@ const Pagination: React.FC<PaginationProps> = ({
     if (query.region) params.append('region', query.region);
     if (query.service) params.append('service', query.service);
     if (page > 1) params.append('page', page.toString());
-    
+    if (pageSize !== 50) params.append('pageSize', pageSize.toString());
+
     return `/?${params.toString()}`;
   };
-  
-  // Don't render pagination if we only have one page
-  if (totalPages <= 1) return null;
-  
+
+  const handlePageSizeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    const newSize = value === 'all' ? totalItems : parseInt(value, 10);
+
+    const params = new URLSearchParams();
+    if (query.ipOrDomain) params.append('ipOrDomain', query.ipOrDomain);
+    if (query.region) params.append('region', query.region);
+    if (query.service) params.append('service', query.service);
+    if (newSize !== 50) params.append('pageSize', newSize.toString());
+
+    router.push(`/?${params.toString()}`);
+  };
+
+  const hasMultiplePages = totalPages > 1;
+
   // Calculate range of items being shown
   const startItem = (currentPage - 1) * pageSize + 1;
   const endItem = Math.min(currentPage * pageSize, totalItems);
-  
+
   // Get pages to display
   const pageNumbers = getPageNumbers();
-  
+
+  const selectValue = pageSize >= totalItems ? 'all' : pageSize.toString();
+
   return (
     <nav className="flex justify-between items-center my-4" aria-label="Search results pagination">
-      <div className="text-sm text-gray-700">
-        Showing items <span className="font-medium">{startItem}</span> to <span className="font-medium">{endItem}</span> of <span className="font-medium">{totalItems}</span>
+      <div className="text-sm text-gray-700 flex items-center gap-4">
+        <span>
+          Showing items <span className="font-medium">{startItem}</span> to <span className="font-medium">{endItem}</span> of <span className="font-medium">{totalItems}</span>
+        </span>
+        <label className="flex items-center gap-1">
+          Items per page:
+          <select
+            className="border-gray-300 rounded-md text-sm"
+            value={selectValue}
+            onChange={handlePageSizeChange}
+          >
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+            <option value="100">100</option>
+            <option value="all">All</option>
+          </select>
+        </label>
       </div>
 
       <div className="flex gap-2" role="navigation" aria-label="Pagination">
-        {/* Previous button */}
-        {currentPage > 1 && (
-          <Link href={getPageUrl(currentPage - 1)} className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200">
-            Previous
-          </Link>
-        )}
-        
-        {/* Page numbers */}
-        {pageNumbers.map((page, index) => {
-          if (page < 0) {
-            // Ellipsis
-            return <span key={`ellipsis-${index}`} className="px-3 py-1">...</span>;
-          }
-          
-          return (
-            <Link
-              key={page}
-              href={getPageUrl(page)}
-              className={`px-3 py-1 rounded-md text-sm ${
-                currentPage === page
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              {page}
-            </Link>
-          );
-        })}
-        
-        {/* Next button */}
-        {currentPage < totalPages && (
-          <Link href={getPageUrl(currentPage + 1)} className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200">
-            Next
-          </Link>
+        {hasMultiplePages && (
+          <>
+            {currentPage > 1 && (
+              <Link href={getPageUrl(currentPage - 1)} className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200">
+                Previous
+              </Link>
+            )}
+
+            {pageNumbers.map((page, index) => {
+              if (page < 0) {
+                // Ellipsis
+                return <span key={`ellipsis-${index}`} className="px-3 py-1">...</span>;
+              }
+
+              return (
+                <Link
+                  key={page}
+                  href={getPageUrl(page)}
+                  className={`px-3 py-1 rounded-md text-sm ${
+                    currentPage === page
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  }`}
+                >
+                  {page}
+                </Link>
+              );
+            })}
+
+            {currentPage < totalPages && (
+              <Link href={getPageUrl(currentPage + 1)} className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200">
+                Next
+              </Link>
+            )}
+          </>
         )}
       </div>
     </nav>

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -1,5 +1,5 @@
 import { AzureIpAddress } from '@/types/azure';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, type ReactNode } from 'react';
 import Tooltip from './Tooltip';
 import ExportDropdown from './ExportDropdown';
 
@@ -20,6 +20,8 @@ interface ResultsProps {
   results: AzureIpAddress[];
   query: string;
   total?: number;
+  topPagination?: ReactNode;
+  bottomPagination?: ReactNode;
 }
 
 type SortField = 'serviceTagId' | 'ipAddressPrefix' | 'region' | 'systemService' | 'networkFeatures';
@@ -29,10 +31,8 @@ export default function Results({ results, query, total }: ResultsProps) {
   const [sortField, setSortField] = useState<SortField>('serviceTagId');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
   
-  // Format the display for total results if we're showing a subset
-  const totalDisplay = total && total > results.length 
-    ? `${results.length} of ${total}` 
-    : results.length;
+  // Always show the total number of matching results
+  const totalDisplay = total ?? results.length;
   
   // Handle column sort
   const handleSort = (field: SortField) => {
@@ -82,7 +82,7 @@ export default function Results({ results, query, total }: ResultsProps) {
               Results for {query}
             </h2>
             <p className="text-sm text-blue-600">
-              Found {totalDisplay} matching Azure IP {results.length === 1 ? 'range' : 'ranges'}
+              Found {totalDisplay} matching Azure IP {totalDisplay === 1 ? 'range' : 'ranges'}
             </p>
           </div>
           <div className="flex-shrink-0">
@@ -90,7 +90,9 @@ export default function Results({ results, query, total }: ResultsProps) {
           </div>
         </div>
       </header>
-      
+
+      {topPagination}
+
       <div className="overflow-x-auto w-full">
         <table className="min-w-full divide-y divide-gray-200 table-fixed relative" aria-label="Azure IP Ranges">
           <thead className="bg-gray-50 relative">
@@ -164,6 +166,8 @@ export default function Results({ results, query, total }: ResultsProps) {
           </tbody>
         </table>
       </div>
+
+      {bottomPagination}
     </section>
   );
 }

--- a/src/components/SimplePagination.tsx
+++ b/src/components/SimplePagination.tsx
@@ -6,6 +6,7 @@ interface SimplePaginationProps {
   onPageChange: (page: number) => void;
   totalItems: number;
   pageSize: number;
+  onPageSizeChange?: (size: number) => void;
 }
 
 const SimplePagination: React.FC<SimplePaginationProps> = ({
@@ -13,10 +14,16 @@ const SimplePagination: React.FC<SimplePaginationProps> = ({
   totalPages,
   onPageChange,
   totalItems,
-  pageSize
+  pageSize,
+  onPageSizeChange
 }) => {
-  // Don't render pagination if we only have one page
-  if (totalPages <= 1) return null;
+  const handlePageSizeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    const newSize = value === 'all' ? totalItems : parseInt(value, 10);
+    onPageSizeChange?.(newSize);
+  };
+
+  const hasMultiplePages = totalPages > 1;
 
   // Calculate range of items being shown
   const startItem = (currentPage - 1) * pageSize + 1;
@@ -57,53 +64,72 @@ const SimplePagination: React.FC<SimplePaginationProps> = ({
 
   const pageNumbers = getPageNumbers();
 
+  const selectValue = pageSize >= totalItems ? 'all' : pageSize.toString();
+
   return (
     <nav className="flex justify-between items-center my-4" aria-label="Results pagination">
-      <div className="text-sm text-gray-700">
-        Showing items <span className="font-medium">{startItem}</span> to <span className="font-medium">{endItem}</span> of <span className="font-medium">{totalItems}</span>
+      <div className="text-sm text-gray-700 flex items-center gap-4">
+        <span>
+          Showing items <span className="font-medium">{startItem}</span> to <span className="font-medium">{endItem}</span> of <span className="font-medium">{totalItems}</span>
+        </span>
+        <label className="flex items-center gap-1">
+          Items per page:
+          <select
+            className="border-gray-300 rounded-md text-sm"
+            value={selectValue}
+            onChange={handlePageSizeChange}
+          >
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+            <option value="100">100</option>
+            <option value="all">All</option>
+          </select>
+        </label>
       </div>
 
       <div className="flex gap-2" role="navigation" aria-label="Pagination">
-        {/* Previous button */}
-        {currentPage > 1 && (
-          <button 
-            onClick={() => onPageChange(currentPage - 1)} 
-            className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200"
-          >
-            Previous
-          </button>
-        )}
-        
-        {/* Page numbers */}
-        {pageNumbers.map((page, index) => {
-          if (page < 0) {
-            // Ellipsis
-            return <span key={`ellipsis-${index}`} className="px-3 py-1">...</span>;
-          }
-          
-          return (
-            <button
-              key={page}
-              onClick={() => onPageChange(page)}
-              className={`px-3 py-1 rounded-md text-sm ${
-                currentPage === page
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              {page}
-            </button>
-          );
-        })}
-        
-        {/* Next button */}
-        {currentPage < totalPages && (
-          <button 
-            onClick={() => onPageChange(currentPage + 1)} 
-            className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200"
-          >
-            Next
-          </button>
+        {hasMultiplePages && (
+          <>
+            {currentPage > 1 && (
+              <button
+                onClick={() => onPageChange(currentPage - 1)}
+                className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200"
+              >
+                Previous
+              </button>
+            )}
+
+            {pageNumbers.map((page, index) => {
+              if (page < 0) {
+                // Ellipsis
+                return <span key={`ellipsis-${index}`} className="px-3 py-1">...</span>;
+              }
+
+              return (
+                <button
+                  key={page}
+                  onClick={() => onPageChange(page)}
+                  className={`px-3 py-1 rounded-md text-sm ${
+                    currentPage === page
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  }`}
+                >
+                  {page}
+                </button>
+              );
+            })}
+
+            {currentPage < totalPages && (
+              <button
+                onClick={() => onPageChange(currentPage + 1)}
+                className="px-3 py-1 rounded-md text-sm bg-gray-100 text-gray-700 hover:bg-gray-200"
+              >
+                Next
+              </button>
+            )}
+          </>
         )}
       </div>
     </nav>

--- a/src/pages/service-tags/[serviceTag].tsx
+++ b/src/pages/service-tags/[serviceTag].tsx
@@ -27,12 +27,11 @@ interface ServiceTagDetailResponse {
   message?: string;
 }
 
-const PAGE_SIZE = 100;
-
 export default function ServiceTagDetail() {
   const router = useRouter();
   const { serviceTag } = router.query;
   const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(50);
   
   const { data, error, isLoading } = useSWR<ServiceTagDetailResponse>(
     serviceTag ? `/api/service-tags?serviceTag=${encodeURIComponent(serviceTag as string)}` : null,
@@ -42,13 +41,13 @@ export default function ServiceTagDetail() {
   // Paginate results
   const paginatedResults = useMemo(() => {
     if (!data?.ipRanges) return [];
-    
-    const startIndex = (currentPage - 1) * PAGE_SIZE;
-    const endIndex = startIndex + PAGE_SIZE;
-    return data.ipRanges.slice(startIndex, endIndex);
-  }, [data?.ipRanges, currentPage]);
 
-  const totalPages = Math.ceil((data?.ipRanges?.length || 0) / PAGE_SIZE);
+    const startIndex = (currentPage - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    return data.ipRanges.slice(startIndex, endIndex);
+  }, [data?.ipRanges, currentPage, pageSize]);
+
+  const totalPages = Math.ceil((data?.ipRanges?.length || 0) / pageSize);
 
   if (!serviceTag) {
     return (
@@ -158,22 +157,37 @@ export default function ServiceTagDetail() {
             </div>
 
             {/* Results Table */}
-            <Results 
-              results={paginatedResults} 
+            <Results
+              results={paginatedResults}
               query={serviceTag as string}
               total={data.ipRanges.length}
+              topPagination={
+                <SimplePagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  onPageChange={setCurrentPage}
+                  totalItems={data.ipRanges.length}
+                  pageSize={pageSize}
+                  onPageSizeChange={(size) => {
+                    setPageSize(size);
+                    setCurrentPage(1);
+                  }}
+                />
+              }
+              bottomPagination={
+                <SimplePagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  onPageChange={setCurrentPage}
+                  totalItems={data.ipRanges.length}
+                  pageSize={pageSize}
+                  onPageSizeChange={(size) => {
+                    setPageSize(size);
+                    setCurrentPage(1);
+                  }}
+                />
+              }
             />
-
-            {/* Pagination */}
-            {totalPages > 1 && (
-              <SimplePagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                onPageChange={setCurrentPage}
-                totalItems={data.ipRanges.length}
-                pageSize={PAGE_SIZE}
-              />
-            )}
           </>
         )}
 


### PR DESCRIPTION
## Summary
- Display total Azure IP ranges in results header
- Provide pagination controls at both top and bottom with page size selector
- Support adjustable page size from 10 to All

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68959299e4688331a16dd8a4f209096e