### PR TITLE
Simplify UI with light minimal theme

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -160,14 +160,14 @@ export default function Layout({ title = 'Azure IP Lookup', children }: LayoutPr
 
       
       <div className="min-h-screen flex flex-col">
-        <header className="bg-gradient-to-r from-blue-700 to-blue-600 text-white shadow-lg">
+        <header className="bg-white border-b border-gray-200 text-gray-800">
           <div className="container mx-auto px-4">
             <nav className="flex flex-col sm:flex-row justify-between items-center py-4">
               <Link href="/" className="flex items-center text-2xl font-bold mb-2 sm:mb-0" aria-label="Azure IP Lookup - Home">
-                <svg 
-                  xmlns="http://www.w3.org/2000/svg" 
-                  className="h-8 w-8 mr-2" 
-                  viewBox="0 0 24 24" 
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-8 w-8 mr-2 text-blue-600"
+                  viewBox="0 0 24 24"
                   fill="currentColor"
                   role="img"
                   aria-label="Azure IP Lookup Logo - Eye icon representing network visibility"
@@ -178,45 +178,45 @@ export default function Layout({ title = 'Azure IP Lookup', children }: LayoutPr
                 <span>Azure IP Lookup</span>
               </Link>
               
-              <div className="flex items-center space-x-1">
-                <Link 
-                  href="/" 
-                  className={`px-3 py-2 rounded-md font-medium text-sm ${
-                    isActive('/') 
-                      ? 'bg-blue-800 text-white' 
-                      : 'text-blue-100 hover:bg-blue-600'
+              <div className="flex items-center space-x-1 text-sm">
+                <Link
+                  href="/"
+                  className={`px-3 py-2 rounded-md font-medium ${
+                    isActive('/')
+                      ? 'text-blue-600 underline'
+                      : 'text-gray-600 hover:text-gray-900'
                   }`}
                 >
                   Home
                 </Link>
                 
-                <Link 
-                  href="/service-tags" 
-                  className={`px-3 py-2 rounded-md font-medium text-sm ${
-                    isActive('/service-tags') || router.pathname.startsWith('/service-tags') 
-                      ? 'bg-blue-800 text-white' 
-                      : 'text-blue-100 hover:bg-blue-600'
+                <Link
+                  href="/service-tags"
+                  className={`px-3 py-2 rounded-md font-medium ${
+                    isActive('/service-tags') || router.pathname.startsWith('/service-tags')
+                      ? 'text-blue-600 underline'
+                      : 'text-gray-600 hover:text-gray-900'
                   }`}
                 >
                   Service Tags
                 </Link>
                 
-                <Link 
-                  href="/about" 
-                  className={`px-3 py-2 rounded-md font-medium text-sm ${
-                    isActive('/about') 
-                      ? 'bg-blue-800 text-white' 
-                      : 'text-blue-100 hover:bg-blue-600'
+                <Link
+                  href="/about"
+                  className={`px-3 py-2 rounded-md font-medium ${
+                    isActive('/about')
+                      ? 'text-blue-600 underline'
+                      : 'text-gray-600 hover:text-gray-900'
                   }`}
                 >
                   About
                 </Link>
                 
-                <a 
+                <a
                   href="https://github.com/endgor/azure-ip-lookup"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="px-3 py-2 rounded-md text-sm font-medium text-blue-100 hover:bg-blue-600 flex items-center"
+                  className="px-3 py-2 rounded-md font-medium text-gray-600 hover:text-gray-900 flex items-center"
                   aria-label="View Azure IP Lookup source code on GitHub"
                 >
                   <svg className="h-5 w-5 mr-1" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" role="img">

--- a/src/components/LookupForm.tsx
+++ b/src/components/LookupForm.tsx
@@ -130,9 +130,9 @@ const LookupForm = memo(function LookupForm({
           className="flex-grow border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
           aria-label="Search query"
         />
-        <button 
-          type="submit" 
-          className={`bg-blue-600 text-white px-6 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors ${
+        <button
+          type="submit"
+          className={`bg-blue-500 text-white px-6 py-2 rounded-lg font-medium hover:bg-blue-600 transition-colors ${
             isLoading ? 'opacity-70 cursor-not-allowed' : ''
           }`}
           disabled={isLoading}

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -79,14 +79,14 @@ const Results = memo(function Results({ results, query, total }: ResultsProps) {
   };
   
   return (
-    <section className="bg-white rounded-lg shadow-md overflow-hidden mb-6" aria-label="Search Results">
-      <header className="bg-blue-50 px-4 py-3 border-b border-blue-100">
+    <section className="bg-white rounded-lg shadow-sm overflow-hidden mb-6" aria-label="Search Results">
+      <header className="bg-gray-50 px-4 py-3 border-b border-gray-200">
         <div className="flex justify-between items-center">
           <div>
-            <h2 className="text-lg font-semibold text-blue-800">
+            <h2 className="text-lg font-semibold text-gray-800">
               Results for {query}
             </h2>
-            <p className="text-sm text-blue-600">
+            <p className="text-sm text-gray-600">
               Found {totalDisplay} matching Azure IP {totalDisplay === 1 ? 'range' : 'ranges'}
             </p>
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,7 +4,7 @@
 
 :root {
   --foreground-rgb: 0, 0, 0;
-  --background-rgb: 249, 250, 251;
+  --background-rgb: 255, 255, 255;
 }
 
 body {
@@ -15,15 +15,15 @@ body {
 }
 
 .prose h1 {
-  @apply text-3xl font-bold mb-6 text-blue-800;
+  @apply text-3xl font-bold mb-6 text-gray-900;
 }
 
 .prose h2 {
-  @apply text-2xl font-semibold mt-8 mb-4 text-blue-700;
+  @apply text-2xl font-semibold mt-8 mb-4 text-gray-800;
 }
 
 .prose h3 {
-  @apply text-xl font-semibold mt-6 mb-3 text-blue-600;
+  @apply text-xl font-semibold mt-6 mb-3 text-gray-700;
 }
 
 .prose p {


### PR DESCRIPTION
## Summary
- Replace gradient header with clean white navigation
- Lighten lookup form and results styling for minimal Azure look
- Update global styles for neutral headings and background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*


------
https://chatgpt.com/codex/tasks/task_e_68b7266ce46c833194bfb887176eb907