### PR TITLE
Remove explore section and limit footer to home page

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,6 +12,7 @@ interface LayoutProps {
 export default function Layout({ title = 'Azure IP Lookup', children }: LayoutProps) {
   const router = useRouter();
   const isActive = (path: string) => router.pathname === path;
+  const showFooter = router.pathname === '/';
   
   // Generate more SEO-optimized titles based on the page
   let fullTitle = title;
@@ -234,37 +235,39 @@ export default function Layout({ title = 'Azure IP Lookup', children }: LayoutPr
           {children}
         </main>
         
-        <footer className="bg-gray-50 border-t">
-          <div className="container mx-auto px-4 py-6 text-center text-gray-600">
-            <p className="font-medium">Azure IP Lookup Tool</p>
-            <p className="text-sm mt-1 mb-2">
-              Data automatically updates daily from Microsoft&apos;s official sources
-            </p>
-            <div className="flex justify-center space-x-4 text-sm">
-              <a 
-                href="https://www.microsoft.com/en-us/download/details.aspx?id=56519"
-                className="text-blue-600 hover:underline"
-                target="_blank" 
-                rel="noopener noreferrer"
-              >
-                Official Data Source
-              </a>
-              <span className="text-gray-400">|</span>
-              <Link href="/about" className="text-blue-600 hover:underline">
-                About
-              </Link>
-              <span className="text-gray-400">|</span>
-              <a 
-                href="https://github.com/endgor/azure-ip-lookup"
-                className="text-blue-600 hover:underline"
-                target="_blank" 
-                rel="noopener noreferrer"
-              >
-                GitHub Repository
-              </a>
+        {showFooter && (
+          <footer className="bg-gray-50 border-t">
+            <div className="container mx-auto px-4 py-6 text-center text-gray-600">
+              <p className="font-medium">Azure IP Lookup Tool</p>
+              <p className="text-sm mt-1 mb-2">
+                Data automatically updates daily from Microsoft&apos;s official sources
+              </p>
+              <div className="flex justify-center space-x-4 text-sm">
+                <a
+                  href="https://www.microsoft.com/en-us/download/details.aspx?id=56519"
+                  className="text-blue-600 hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Official Data Source
+                </a>
+                <span className="text-gray-400">|</span>
+                <Link href="/about" className="text-blue-600 hover:underline">
+                  About
+                </Link>
+                <span className="text-gray-400">|</span>
+                <a
+                  href="https://github.com/endgor/azure-ip-lookup"
+                  className="text-blue-600 hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  GitHub Repository
+                </a>
+              </div>
             </div>
-          </div>
-        </footer>
+          </footer>
+        )}
       </div>
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import Link from 'next/link';
 import Layout from '@/components/Layout';
 import LookupForm from '@/components/LookupForm';
 import Results from '@/components/Results';
@@ -346,35 +345,6 @@ export default function Home() {
             </div>
           </section>
 
-          <section className="max-w-3xl mx-auto mt-12">
-            <h2 className="text-2xl font-semibold mb-6 text-gray-800">Explore More</h2>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow">
-                <h3 className="text-lg font-semibold mb-3 text-blue-800">Browse All Service Tags</h3>
-                <p className="text-gray-600 mb-4">
-                  Explore the complete directory of Azure Service Tags and their associated IP ranges.
-                </p>
-                <Link 
-                  href="/service-tags"
-                  className="inline-flex items-center text-blue-600 font-medium hover:text-blue-800"
-                >
-                  View Service Tags Directory →
-                </Link>
-              </div>
-              <div className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow">
-                <h3 className="text-lg font-semibold mb-3 text-blue-800">Learn More About This Tool</h3>
-                <p className="text-gray-600 mb-4">
-                  Discover how the Azure IP Lookup Tool works, its data sources, and technical details.
-                </p>
-                <Link 
-                  href="/about"
-                  className="inline-flex items-center text-blue-600 font-medium hover:text-blue-800"
-                >
-                  Read About Page →
-                </Link>
-              </div>
-            </div>
-          </section>
         </>
       )}
     </Layout>


### PR DESCRIPTION
## Summary
- drop Explore More section from homepage to streamline layout
- show footer with data source links only on the home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7309faf208331be487c54d7db842a