### PR TITLE
Remove landing page extras and site-wide footer

### DIFF
--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -329,13 +329,6 @@
             </div>
         </div>
     </main>
-
-    <footer class="footer">
-        <div class="footer-text">
-            Azure IP Lookup Tool - Temporarily under maintenance
-        </div>
-    </footer>
-
     <script>
         // Auto-refresh after 5 minutes if user doesn't manually refresh
         setTimeout(function() {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -237,38 +237,6 @@ export default function Layout({ title = 'Azure IP Lookup', children }: LayoutPr
         <main className="flex-grow container mx-auto px-4 py-8">
           {children}
         </main>
-        
-        <footer className="bg-gray-50 border-t">
-          <div className="container mx-auto px-4 py-6 text-center text-gray-600">
-            <p className="font-medium">Azure IP Lookup Tool</p>
-            <p className="text-sm mt-1 mb-2">
-              Data automatically updates daily from Microsoft&apos;s official sources
-            </p>
-            <div className="flex justify-center space-x-4 text-sm">
-              <a
-                href="https://www.microsoft.com/en-us/download/details.aspx?id=56519"
-                className="text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Official Data Source
-              </a>
-              <span className="text-gray-400">|</span>
-              <Link href="/about" className="text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded">
-                About
-              </Link>
-              <span className="text-gray-400">|</span>
-              <a
-                href="https://github.com/endgor/azure-ip-lookup"
-                className="text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                GitHub Repository
-              </a>
-            </div>
-          </div>
-        </footer>
       </div>
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import Link from 'next/link';
 import Layout from '@/components/Layout';
 import LookupForm from '@/components/LookupForm';
 import Results from '@/components/Results';
@@ -319,63 +318,31 @@ export default function Home() {
       </div>
       
       {!initialQuery && !initialRegion && !initialService && (
-        <>
-          <section className="max-w-4xl mx-auto mt-12">
-            <h2 className="text-2xl font-semibold mb-6 text-gray-800 text-center">Examples</h2>
-            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
-              <div className="bg-blue-50 p-4 rounded-lg">
-                <h3 className="text-lg font-semibold text-blue-800 mb-2">IP Address</h3>
-                <p className="mb-2">Example: <code className="bg-blue-100 px-2 py-1 rounded text-sm">40.112.127.224</code></p>
-                <p className="text-gray-600">Verify if an IP belongs to Azure and discover which services are using it.</p>
-              </div>
-              <div className="bg-blue-50 p-4 rounded-lg">
-                <h3 className="text-lg font-semibold text-blue-800 mb-2">CIDR Range</h3>
-                <p className="mb-2">Example: <code className="bg-blue-100 px-2 py-1 rounded text-sm">74.7.51.32/29</code></p>
-                <p className="text-gray-600">Find Azure IP ranges that overlap with your specified CIDR block.</p>
-              </div>
-              <div className="bg-blue-50 p-4 rounded-lg">
-                <h3 className="text-lg font-semibold text-blue-800 mb-2">Service Name</h3>
-                <p className="mb-2">Example: <code className="bg-blue-100 px-2 py-1 rounded text-sm">Storage</code></p>
-                <p className="text-gray-600">Browse IP ranges for specific Azure services like Storage, SQL, or Compute.</p>
-              </div>
-              <div className="bg-blue-50 p-4 rounded-lg">
-                <h3 className="text-lg font-semibold text-blue-800 mb-2">Region</h3>
-                <p className="mb-2">Example: <code className="bg-blue-100 px-2 py-1 rounded text-sm">WestEurope</code></p>
-                <p className="text-gray-600">View IP ranges for specific regions or service+region combinations.</p>
-              </div>
+        <section className="max-w-4xl mx-auto mt-12">
+          <h2 className="text-2xl font-semibold mb-6 text-gray-800 text-center">Examples</h2>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="bg-blue-50 p-4 rounded-lg">
+              <h3 className="text-lg font-semibold text-blue-800 mb-2">IP Address</h3>
+              <p className="mb-2">Example: <code className="bg-blue-100 px-2 py-1 rounded text-sm">40.112.127.224</code></p>
+              <p className="text-gray-600">Verify if an IP belongs to Azure and discover which services are using it.</p>
             </div>
-          </section>
-
-          <section className="max-w-3xl mx-auto mt-12">
-            <h2 className="text-2xl font-semibold mb-6 text-gray-800">Explore More</h2>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow">
-                <h3 className="text-lg font-semibold mb-3 text-blue-800">Browse All Service Tags</h3>
-                <p className="text-gray-600 mb-4">
-                  Explore the complete directory of Azure Service Tags and their associated IP ranges.
-                </p>
-                <Link 
-                  href="/service-tags"
-                  className="inline-flex items-center text-blue-600 font-medium hover:text-blue-800"
-                >
-                  View Service Tags Directory →
-                </Link>
-              </div>
-              <div className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow">
-                <h3 className="text-lg font-semibold mb-3 text-blue-800">Learn More About This Tool</h3>
-                <p className="text-gray-600 mb-4">
-                  Discover how the Azure IP Lookup Tool works, its data sources, and technical details.
-                </p>
-                <Link 
-                  href="/about"
-                  className="inline-flex items-center text-blue-600 font-medium hover:text-blue-800"
-                >
-                  Read About Page →
-                </Link>
-              </div>
+            <div className="bg-blue-50 p-4 rounded-lg">
+              <h3 className="text-lg font-semibold text-blue-800 mb-2">CIDR Range</h3>
+              <p className="mb-2">Example: <code className="bg-blue-100 px-2 py-1 rounded text-sm">74.7.51.32/29</code></p>
+              <p className="text-gray-600">Find Azure IP ranges that overlap with your specified CIDR block.</p>
             </div>
-          </section>
-        </>
+            <div className="bg-blue-50 p-4 rounded-lg">
+              <h3 className="text-lg font-semibold text-blue-800 mb-2">Service Name</h3>
+              <p className="mb-2">Example: <code className="bg-blue-100 px-2 py-1 rounded text-sm">Storage</code></p>
+              <p className="text-gray-600">Browse IP ranges for specific Azure services like Storage, SQL, or Compute.</p>
+            </div>
+            <div className="bg-blue-50 p-4 rounded-lg">
+              <h3 className="text-lg font-semibold text-blue-800 mb-2">Region</h3>
+              <p className="mb-2">Example: <code className="bg-blue-100 px-2 py-1 rounded text-sm">WestEurope</code></p>
+              <p className="text-gray-600">View IP ranges for specific regions or service+region combinations.</p>
+            </div>
+          </div>
+        </section>
       )}
     </Layout>
   );

--- a/src/pages/maintenance.tsx
+++ b/src/pages/maintenance.tsx
@@ -133,13 +133,6 @@ export default function Maintenance() {
             </div>
           </div>
         </main>
-
-        {/* Footer */}
-        <footer className="bg-gray-50 border-t">
-          <div className="container mx-auto px-4 py-4 text-center text-sm text-gray-600">
-            <p>Azure IP Lookup Tool - Temporarily under maintenance</p>
-          </div>
-        </footer>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- drop Explore More links from homepage
- remove global footer and maintenance footers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7cd6a7d44833194eee642f17a2d7b